### PR TITLE
Ruamel dependency

### DIFF
--- a/conda_vendor/__main__.py
+++ b/conda_vendor/__main__.py
@@ -9,7 +9,7 @@ from conda_vendor.cli import (
 )
 from conda_vendor.version import __version__
 from conda_vendor.manifest import combine_metamanifests, write_combined_manifest
-import yaml
+from ruamel.yaml import YAML
 import logging
 
 logger = logging.getLogger(__name__)

--- a/conda_vendor/__main__.py
+++ b/conda_vendor/__main__.py
@@ -8,7 +8,7 @@ from conda_vendor.cli import (
     yaml_from_manifest,
 )
 from conda_vendor.version import __version__
-from conda_vendor.manifest import combine_metamanifests
+from conda_vendor.manifest import combine_metamanifests, write_combined_manifest
 import yaml
 import logging
 
@@ -97,8 +97,7 @@ def combine_manifests(verbose, meta_manifest_paths, output_combined_path):
     combined_manifest = combine_metamanifests(manifest_paths=paths)
 
     logger.info(f"Writing combined manifest to: {output_combined_path}")
-    with open(output_combined_path, "w") as f:
-        yaml.dump(combined_manifest, f, sort_keys=False)
+    write_combined_manifest(output_combined_path, combined_manifest)
 
 
 @click.command(help="local channels from meta-manifest file")

--- a/conda_vendor/__main__.py
+++ b/conda_vendor/__main__.py
@@ -98,7 +98,7 @@ def combine_manifests(verbose, meta_manifest_paths, output_combined_path):
 
     logger.info(f"Writing combined manifest to: {output_combined_path}")
     with open(output_combined_path, "w") as f:
-        yaml.dump(combined_manifest, sort_keys=False)
+        yaml.dump(combined_manifest, f, sort_keys=False)
 
 
 @click.command(help="local channels from meta-manifest file")

--- a/conda_vendor/conda_channel.py
+++ b/conda_vendor/conda_channel.py
@@ -78,7 +78,6 @@ class CondaChannel:
     def get_all_repo_data(self):
         if self.all_repo_data:
             return self.all_repo_data
-        # this is where
         all_repo_data = {}
 
         for chan in self.channels:

--- a/conda_vendor/conda_channel.py
+++ b/conda_vendor/conda_channel.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 import requests
-import yaml
+from ruamel.yaml import YAML
 from conda_lock.conda_lock import solve_specs_for_arch
 from conda_lock.src_parser.environment_yaml import parse_environment_file
 from requests.adapters import HTTPAdapter
@@ -37,7 +37,9 @@ class CondaChannel:
 
     def load_manifest(self, manifest_path):
         with open(manifest_path) as f:
-            return yaml.load(f, Loader=yaml.SafeLoader)
+            return YAML(typ="safe").load(
+                f,
+            )
 
     def fetch_and_filter_repodata(self, conda_subdir, manifest_subset_metadata):
         # returns a channel specific repodata.json

--- a/conda_vendor/custom_manifest.py
+++ b/conda_vendor/custom_manifest.py
@@ -3,7 +3,7 @@ import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-import yaml
+from ruamel.yaml import YAML
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,9 @@ class CustomManifest(ABC):
 
     def read_meta_manifest(self, manifest_path):
         with open(self.manifest_path) as f:
-            return yaml.load(f, Loader=yaml.SafeLoader)
+            return YAML(typ="safe").load(
+                f,
+            )
 
     @abstractmethod
     def write_custom_manifest(self, output_path=None):
@@ -38,7 +40,10 @@ class IBManifest(CustomManifest):
 
         logger.info(f"Output Custom Manifest : {str(output_file_path.absolute())}")
         with open(output_file_path, "w") as f:
-            yaml.dump(self.custom_manifest, f, sort_keys=False)
+            YAML().dump(
+                self.custom_manifest,
+                f,
+            )
 
     @staticmethod
     def strip_lead_underscore(in_str):

--- a/conda_vendor/env_yaml_from_manifest.py
+++ b/conda_vendor/env_yaml_from_manifest.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml import YAML
 
 
 class YamlFromManifest:
@@ -10,7 +10,9 @@ class YamlFromManifest:
 
     def load_manifest(self, meta_manifest_path):
         with open(meta_manifest_path) as f:
-            return yaml.load(f, Loader=yaml.SafeLoader)
+            return YAML(typ="safe").load(
+                f,
+            )
 
     def get_packages_from_manifest(self):
         i_bank_pkg_list = []
@@ -40,5 +42,8 @@ class YamlFromManifest:
         }
         fn = channel_root / f"local_{env_name}.yaml"
         with open(fn, "w") as f:
-            yaml.dump(env_yaml, f, sort_keys=False)
+            YAML().dump(
+                env_yaml,
+                f,
+            )
         return env_yaml

--- a/conda_vendor/manifest.py
+++ b/conda_vendor/manifest.py
@@ -17,52 +17,6 @@ from requests.packages.urllib3.util.retry import Retry
 logger = logging.getLogger(__name__)
 
 
-def combine_metamanifests(manifest_paths):
-    manifests = read_manifests(manifest_paths)
-
-    combined = {}
-    for manifest in manifests:
-        for channel in manifest.keys():
-            if not channel in combined.keys():
-                combined[channel] = manifest[channel]
-            else:
-                for arch in manifest[channel].keys():
-                    if arch in combined[channel].keys():
-                        pkg_list = deduplicate_pkg_list(
-                            combined[channel][arch]["entries"]
-                            + manifest[channel][arch]["entries"]
-                        )
-                        combined[channel][arch]["entries"] = pkg_list
-                    else:
-                        combined[channel][arch]["entries"] = manifest[channel][arch][
-                            "entries"
-                        ]
-                        combined[channel][arch]["repodata_url"] = manifest[channel][
-                            arch
-                        ]["repodata_url"]
-    return combined
-
-
-def deduplicate_pkg_list(package_list):
-    seen_shas = set()
-    deduped_list = []
-
-    for package in package_list:
-        if package["sha256"] not in seen_shas:
-            deduped_list.append(package)
-            seen_shas.add(package["sha256"])
-
-    return deduped_list
-
-
-def read_manifests(manifest_paths):
-    manifest_list = []
-    for manifest_path in manifest_paths:
-        with open(manifest_path, "r") as f:
-            manifest_list.append(yaml.safe_load(f))
-    return manifest_list
-
-
 class LockWrapper:
     @staticmethod
     def parse(*args):
@@ -118,13 +72,9 @@ class MetaManifest:
         }
 
         logger.info(f"Using Environment :{environment_yml}")
-        with open(environment_yml) as f:
-            self.env_deps["environment"] = yaml.load(f, Loader=yaml.SafeLoader)
         bad_channels = ["nodefaults"]
         self.channels = [
-            chan
-            for chan in self.env_deps["environment"]["channels"]
-            if chan not in bad_channels
+            chan for chan in self.env_deps["channels"] if chan not in bad_channels
         ]
         if "defaults" in self.channels:
             raise RuntimeError("default channels are not supported.")
@@ -145,11 +95,12 @@ class MetaManifest:
 
     def add_pip_dependency(self):
         add_pip_dependency = self.add_pip_question_mark()
-        dependencies = self.env_deps["environment"]["dependencies"].copy()
+
+        dependencies = self.env_deps["specs"].copy()
         has_python = "python" in "".join(dependencies)
 
         if add_pip_dependency is True and has_python:
-            self.env_deps["environment"]["dependencies"].append("pip")
+            self.env_deps["specs"].append("pip")
 
     def get_manifest_filename(self, manifest_filename=None):
         if manifest_filename is None:
@@ -219,3 +170,49 @@ class MetaManifest:
 
         logger.debug(f'Fetch results: {self.env_deps["solution"]["actions"]["FETCH"]}')
         return self.env_deps["solution"]["actions"]["FETCH"]
+
+
+def combine_metamanifests(manifest_paths):
+    manifests = read_manifests(manifest_paths)
+
+    combined = {}
+    for manifest in manifests:
+        for channel in manifest.keys():
+            if not channel in combined.keys():
+                combined[channel] = manifest[channel]
+            else:
+                for arch in manifest[channel].keys():
+                    if arch in combined[channel].keys():
+                        pkg_list = deduplicate_pkg_list(
+                            combined[channel][arch]["entries"]
+                            + manifest[channel][arch]["entries"]
+                        )
+                        combined[channel][arch]["entries"] = pkg_list
+                    else:
+                        combined[channel][arch]["entries"] = manifest[channel][arch][
+                            "entries"
+                        ]
+                        combined[channel][arch]["repodata_url"] = manifest[channel][
+                            arch
+                        ]["repodata_url"]
+    return combined
+
+
+def deduplicate_pkg_list(package_list):
+    seen_shas = set()
+    deduped_list = []
+
+    for package in package_list:
+        if package["sha256"] not in seen_shas:
+            deduped_list.append(package)
+            seen_shas.add(package["sha256"])
+
+    return deduped_list
+
+
+def read_manifests(manifest_paths):
+    manifest_list = []
+    for manifest_path in manifest_paths:
+        with open(manifest_path, "r") as f:
+            manifest_list.append(yaml.safe_load(f))
+    return manifest_list

--- a/conda_vendor/manifest.py
+++ b/conda_vendor/manifest.py
@@ -216,3 +216,8 @@ def read_manifests(manifest_paths):
         with open(manifest_path, "r") as f:
             manifest_list.append(yaml.safe_load(f))
     return manifest_list
+
+
+def write_combined_manifest(manifest_path, combined_manifest):
+    with open(manifest_path, "w") as f:
+        yaml.dump(combined_manifest, f, sort_keys=False)

--- a/conda_vendor/manifest.py
+++ b/conda_vendor/manifest.py
@@ -6,9 +6,8 @@ import os
 import struct
 import sys
 from pathlib import Path
-
+from ruamel.yaml import YAML
 import requests
-import yaml
 from conda_lock.conda_lock import solve_specs_for_arch
 from conda_lock.src_parser.environment_yaml import parse_environment_file
 from requests.adapters import HTTPAdapter
@@ -118,7 +117,10 @@ class MetaManifest:
         outpath_file_name = self.manifest_root / cleaned_name
         logger.info(f"Creating Manifest {outpath_file_name.absolute()}")
         with open(outpath_file_name, "w") as f:
-            yaml.dump(manifest, f, sort_keys=False)
+            YAML().dump(
+                manifest,
+                f,
+            )
         return manifest
 
     def get_manifest(self):
@@ -214,10 +216,13 @@ def read_manifests(manifest_paths):
     manifest_list = []
     for manifest_path in manifest_paths:
         with open(manifest_path, "r") as f:
-            manifest_list.append(yaml.safe_load(f))
+            manifest_list.append(YAML(typ="safe").load(f))
     return manifest_list
 
 
 def write_combined_manifest(manifest_path, combined_manifest):
     with open(manifest_path, "w") as f:
-        yaml.dump(combined_manifest, f, sort_keys=False)
+        YAML().dump(
+            combined_manifest,
+            f,
+        )

--- a/conda_vendor/version.py
+++ b/conda_vendor/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/conda_vendor/version.py
+++ b/conda_vendor/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/conda_vendor/version.py
+++ b/conda_vendor/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/conda_vendor_container_env.yml
+++ b/conda_vendor_container_env.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - python=3.9.5
   - conda-lock
+  - ruamel.yaml

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(exclude=("tests",), where="."),
     url="https://github.com/MetroStar/conda-vendor",
     entry_points={"console_scripts": ["conda-vendor = conda_vendor.__main__:cli"]},
-    install_requires=["pyyaml", "conda-lock"],
+    install_requires=["ruamel.yaml", "conda-lock"],
     setup_requires=["wheel"],
     python_requires=">=3.6",
     long_description=long_description,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import sys
 from unittest.mock import Mock
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 
 from conda_vendor.conda_channel import CondaChannel
 from conda_vendor.manifest import MetaManifest
@@ -60,7 +60,10 @@ def get_path_location_for_manifest_fixture(tmpdir_factory):
 
     fn = tmpdir_factory.mktemp("minimal_env").join("env.yml")
     with open(fn, "w") as f:
-        yaml.dump(fixture_manifest, f, sort_keys=False)
+        YAML().dump(
+            fixture_manifest,
+            f,
+        )
 
     return fn
 

--- a/tests/test_conda_channel.py
+++ b/tests/test_conda_channel.py
@@ -4,25 +4,24 @@ from unittest import TestCase
 from unittest.mock import Mock, call, mock_open, patch
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 from requests import Response
 from requests.adapters import urldefragauth
 from yaml import safe_load
-from yaml.loader import SafeLoader
-
+from ruamel.yaml import YAML
 from conda_vendor.conda_channel import CondaChannel, improved_download
 from conda_vendor.manifest import LockWrapper, MetaManifest
 
 from .conftest import mock_response
 
 
-@patch("yaml.load")
+@patch("ruamel.yaml.YAML")
 def test_load_manifest(mock, conda_channel_fixture, tmp_path):
     test_manifest_path = tmp_path / "test_manifest.yml"
     with open(test_manifest_path, "w") as y:
         y.write("test")
     conda_channel_fixture.load_manifest(test_manifest_path)
-    mock.assert_called_once_with = [test_manifest_path, yaml.SafeLoader]
+    mock.assert_called_once_with = [test_manifest_path]
 
 
 @patch("requests.Session.get")

--- a/tests/test_custom_manifest.py
+++ b/tests/test_custom_manifest.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import Mock, call, mock_open, patch
 
-import yaml
+from ruamel.yaml import YAML
 
 from conda_vendor.custom_manifest import CustomManifest, IBManifest
 
@@ -40,7 +40,9 @@ def test_write_custom_manifest(mock_read_meta_manifest, tmp_path):
 
     custom_channel.write_custom_manifest(test_output_path)
     with open(expected_custom_manifest_destination, "r") as f:
-        actual_custom_manifest = yaml.load(f, Loader=yaml.SafeLoader)
+        actual_custom_manifest = YAML(typ="safe").load(
+            f,
+        )
 
     assert actual_custom_manifest == expected_custom_manifest
 

--- a/tests/test_env_yaml_from_manifest.py
+++ b/tests/test_env_yaml_from_manifest.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 from yaml import SafeLoader
 
 from conda_vendor.env_yaml_from_manifest import YamlFromManifest
@@ -20,7 +20,7 @@ def yml_man_fixture(tmp_path, get_path_location_for_manifest_fixture):
 def test_YamlFromManifest_init_(yml_man_fixture):
     test_manifest_path = yml_man_fixture.meta_manifest_path
     with open(test_manifest_path, "r") as f:
-        expected = yaml.load(f, Loader=SafeLoader)
+        expected = YAML(typ="safe").load(f)
     result = yml_man_fixture.meta_manifest
     TestCase().assertDictEqual(expected, result)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,7 @@ import subprocess
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-import yaml
+from ruamel.yaml import YAML
 
 from conda_vendor.cli import (
     ironbank_from_meta_manifest,
@@ -39,7 +39,9 @@ def test_meta_manifest_from_env_yml(tmp_path, minimal_conda_forge_environment):
         minimal_conda_forge_environment, tmp_path, test_manifest_filename
     )
     with open(expected_manifest_path) as f:
-        actual_manifest = yaml.load(f, Loader=yaml.SafeLoader)
+        actual_manifest = YAML(typ="safe").load(
+            f,
+        )
 
     assert "main" in actual_manifest.keys()
     assert "conda-forge" in actual_manifest.keys()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -56,13 +56,8 @@ def test_MetaManifest_init(minimal_environment, tmp_path):
     expected_manifest = None
     expected_type = MetaManifest
     expected_env_deps = {
-        "specs": ["python=3.9.5"],
+        "specs": ["python=3.9.5", "pip"],
         "channels": ["main"],
-        "environment": {
-            "name": "minimal_env",
-            "channels": ["main"],
-            "dependencies": ["python=3.9.5", "pip"],
-        },
     }
 
     assert test_meta_manifest.platform is not None
@@ -90,7 +85,7 @@ def test_MetaManifest_solve_environment(mock, meta_manifest_fixture):
     mock.assert_called_with(
         "conda",
         ["main", "conda-forge"],
-        specs=["python=3.9.5", "conda-mirror=0.8.2"],
+        specs=["python=3.9.5", "conda-mirror=0.8.2", "pip"],
         platform=platform,
     )
     TestCase().assertDictEqual(result[0], expected[0])
@@ -254,19 +249,17 @@ def test_add_pip_question_mark(meta_manifest_fixture):
 
 def test_add_pip_dependency(meta_manifest_fixture):
     mock_env_python = {
-        "name": "blah",
         "channels": ["chronotrigger"],
-        "dependencies": ["python"],
+        "specs": ["python"],
     }
 
     expected_env = {
-        "name": "blah",
         "channels": ["chronotrigger"],
-        "dependencies": ["python", "pip"],
+        "specs": ["python", "pip"],
     }
-    meta_manifest_fixture.env_deps["environment"] = mock_env_python
+    meta_manifest_fixture.env_deps = mock_env_python
     meta_manifest_fixture.add_pip_dependency()
-    result = meta_manifest_fixture.env_deps["environment"]
+    result = meta_manifest_fixture.env_deps
 
     TestCase().assertDictEqual(result, expected_env)
 
@@ -352,7 +345,6 @@ def test_combine_metamanifests(tmp_path):
 
     with open(manifest_path_2, "w") as f:
         yaml.dump(test_manifest2, f)
-
 
     actual_return = combine_metamanifests(test_manifests_list)
     assert actual_return == expected_return

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -6,6 +6,7 @@ from conda_vendor.manifest import (
     combine_metamanifests,
     deduplicate_pkg_list,
     read_manifests,
+    write_combined_manifest,
 )
 import pytest
 from requests import Response
@@ -351,8 +352,8 @@ def test_combine_metamanifests(tmp_path):
 
 
 def test_read_manifests(tmp_path):
-    yaml1 = {"key1", "value1"}
-    yaml2 = {"key2", "value2"}
+    yaml1 = {"key1": "value1"}
+    yaml2 = {"key2": "value2"}
 
     yaml_path1 = tmp_path / "yaml1.yaml"
     yaml_path2 = tmp_path / "yaml2.yaml"
@@ -367,3 +368,15 @@ def test_read_manifests(tmp_path):
     actual_manifest_list = read_manifests([yaml_path1, yaml_path2])
 
     assert actual_manifest_list == expected_manifest_list
+
+
+def test_write_combined_manifest(tmp_path):
+    test_yaml = {"key1": "value1"}
+    yaml_path = tmp_path / "test_yaml.yaml"
+
+    write_combined_manifest(yaml_path, test_yaml)
+
+    with open(yaml_path, "r") as f:
+        actual_yaml = yaml.safe_load(f)
+
+    TestCase().assertDictEqual(actual_yaml, test_yaml)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -12,7 +12,7 @@ import pytest
 from requests import Response
 import hashlib
 import json
-import yaml
+from ruamel.yaml import YAML
 from requests import Response
 from unittest import TestCase
 from unittest.mock import Mock, patch, call, mock_open
@@ -227,7 +227,7 @@ def test_create_manifest(meta_manifest_fixture, tmp_path):
     test_manifest_fixture.create_manifest()
 
     with open(expected_path, "r") as f:
-        actual_manifest = yaml.load(f, Loader=SafeLoader)
+        actual_manifest = YAML(typ="safe").load(f)
 
     TestCase().assertDictEqual(actual_manifest, expected_manifest)
 
@@ -342,10 +342,10 @@ def test_combine_metamanifests(tmp_path):
     test_manifests_list = [manifest_path_1, manifest_path_2]
 
     with open(manifest_path_1, "w") as f:
-        yaml.dump(test_manifest1, f)
+        YAML().dump(test_manifest1, f)
 
     with open(manifest_path_2, "w") as f:
-        yaml.dump(test_manifest2, f)
+        YAML().dump(test_manifest2, f)
 
     actual_return = combine_metamanifests(test_manifests_list)
     assert actual_return == expected_return
@@ -359,10 +359,10 @@ def test_read_manifests(tmp_path):
     yaml_path2 = tmp_path / "yaml2.yaml"
 
     with open(yaml_path1, "w") as f:
-        yaml.dump(yaml1, f)
+        YAML().dump(yaml1, f)
 
     with open(yaml_path2, "w") as f:
-        yaml.dump(yaml2, f)
+        YAML().dump(yaml2, f)
 
     expected_manifest_list = [yaml1, yaml2]
     actual_manifest_list = read_manifests([yaml_path1, yaml_path2])
@@ -377,6 +377,6 @@ def test_write_combined_manifest(tmp_path):
     write_combined_manifest(yaml_path, test_yaml)
 
     with open(yaml_path, "r") as f:
-        actual_yaml = yaml.safe_load(f)
+        actual_yaml = YAML(typ="safe").load(f)
 
     TestCase().assertDictEqual(actual_yaml, test_yaml)


### PR DESCRIPTION
- pyyaml silently allows for duplicate keys in yaml files. This was causing an error for some users. Switch dependency to ruamel which throws an error on duplicate keys in yaml files.