### PR TITLE
Use pathlib in conda_vendor.py, fix issue 38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 conda_vendor.egg-info/
 /build
 /conda-vendor-dependencies
+.envrc

--- a/conda_vendor/conda_vendor.py
+++ b/conda_vendor/conda_vendor.py
@@ -58,7 +58,7 @@ def create_vendored_dir(environment_file, platform, desired_path=None) -> Path:
             click.echo(err)
             sys.exit(f"Directory \"{desired_path}/{environment_name}\" already exists")
 
-def create_platform_dir(path, platform):
+def create_platform_dir(path, platform, overwrite=True):
     try:
         platform_path = path / platform
         os.mkdir(platform_path)

--- a/conda_vendor/conda_vendor.py
+++ b/conda_vendor/conda_vendor.py
@@ -2,7 +2,6 @@ import click
 import yaml
 import sys
 import struct
-import os
 import requests
 import hashlib
 import json
@@ -40,7 +39,7 @@ def create_vendored_dir(environment_file, platform, desired_path=None) -> Path:
             root_dir = Path(root_dir) 
 
         path = root_dir / env_name
-        os.mkdir(path)
+        Path.mkdir(path)
         create_platform_dir(path, platform)
         create_noarch_dir(path)
         return path
@@ -61,15 +60,15 @@ def create_vendored_dir(environment_file, platform, desired_path=None) -> Path:
 def create_platform_dir(path, platform, overwrite=True):
     try:
         platform_path = path / platform
-        os.mkdir(platform_path)
+        Path.mkdir(platform_path, exist_ok=overwrite)
     except FileExistsError as err:
         click.echo(err)
         sys.exit(f"Directory \"{platform_path}\" already exists")
 
-def create_noarch_dir(path):
+def create_noarch_dir(path, overwrite=True):
     try:
         noarch_path = path / "noarch"
-        os.mkdir(noarch_path)
+        Path.mkdir(noarch_path, exist_ok=overwrite)
     except FileExistsError as err:
         click.echo(err)
         sys.exit(f"Directory \"{noarch_path}\" already exists")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,8 +36,8 @@ def test_vendor_dry_run(python_main_defaults_environment):
 # NOTE this test expects that 'mamba' is in your path, if you need to, 
 # uncomment the skip decorator
 #@pytest.mark.skip(reason="mamba is not installed or in $PATH")
-def test_vendor_full_runthrough(python_main_defaults_environment, tmpdir):
-    test_path = tmpdir.mkdir("full-runthrough")
+def test_vendor_full_runthrough(python_main_defaults_environment, tmp_path_factory):
+    test_path = tmp_path_factory.mktemp("full-runthrough")
     os.chdir(test_path)
 
     runner = CliRunner()
@@ -78,8 +78,8 @@ def test_fetch_actions(dry_run_install_fixture):
 
 # this integration test runs hotfix_vendored_repodata_json
 # which subsequently calls reconstruct_repodata_json
-def test_hotfix_vendored_repodata_json(fetch_action_packages_fixture, tmpdir):
-    temp_vendored_dir = tmpdir.mkdir("test-hotfix-repodata")
+def test_hotfix_vendored_repodata_json(fetch_action_packages_fixture, tmp_path_factory):
+    temp_vendored_dir = tmp_path_factory.mktemp("test-hotfix-repodata")
     create_platform_dir(temp_vendored_dir, "linux-64")
     create_noarch_dir(temp_vendored_dir)
     hotfix_vendored_repodata_json(fetch_action_packages_fixture, temp_vendored_dir)
@@ -88,8 +88,8 @@ def test_hotfix_vendored_repodata_json(fetch_action_packages_fixture, tmpdir):
 
 
 # this integration test runs the download_solved_pkgs fn
-def test_download_solved_pkgs(fetch_action_packages_fixture, tmpdir):
-    download_dir = tmpdir.mkdir("test-download-target")
+def test_download_solved_pkgs(fetch_action_packages_fixture, tmp_path_factory):
+    download_dir = tmp_path_factory.mktemp("test-download-target")
     create_platform_dir(download_dir, "linux-64")
     create_noarch_dir(download_dir)
     download_solved_pkgs(fetch_action_packages_fixture, download_dir, "linux-64")


### PR DESCRIPTION
Fixes #38 

I believe this fixes the issue that was causing trouble last week. While working through the fix, I took's @kcpevey suggestion and converted path-like objects from `str` to `pathlib.Path` objects. This did also require swapping out the [`tmpdir`](https://docs.pytest.org/en/7.1.x/reference/reference.html?highlight=tmpdir#tmpdir) fixture for [`tmp_path_factory`](https://docs.pytest.org/en/7.1.x/reference/reference.html?highlight=tmpdir#tmp-path-factory), the latter of which returns a `pathlib.Path` object. 

