### PR TITLE
bug fix "packages.conda" not in repodata.json

### DIFF
--- a/conda_vendor/conda_vendor.py
+++ b/conda_vendor/conda_vendor.py
@@ -155,23 +155,27 @@ def reconstruct_repodata_json(repodata_url, dest_dir, fetch_actions):
     }
 
     valid_names = [pkg["fn"] for pkg in fetch_actions]
-
     live_repodata_json = improved_download(repodata_url).json()
-    with click.progressbar(live_repodata_json["packages"].items(), label="Hotfix Patching repodata.json") as repodata_packages:
+    with click.progressbar(
+            live_repodata_json["packages"].items(),
+            label="Hotfix Patching repodata.json [packages]") as repodata_packages:
         if live_repodata_json.get("packages"):
             for name, entry in repodata_packages:
                 if name in valid_names:
                     repo_data["packages"][name] = entry
 
+    with click.progressbar(
+            live_repodata_json["packages.conda"].items(),
+            label="Hotfix Patching repodata.json [packages.conda]") as repodata_packages:
         if live_repodata_json.get("packages.conda"):
             for name, entry in repodata_packages:
                 if name in valid_names:
                     repo_data["packages.conda"][name] = entry
 
-        # write to destination
-        dest_file = Path(f"{dest_dir}/repodata.json")
-        with dest_file.open("w") as f:
-            json.dump(repo_data, f)
+    # write to destination
+    dest_file = Path(f"{dest_dir}/repodata.json")
+    with dest_file.open("w") as f:
+        json.dump(repo_data, f)
 
 # see https://stackoverflow.com/questions/21371809/cleanly-setting-max-retries-on-python-requests-get-or-post-method
 def improved_download(url):

--- a/conda_vendor/version.py
+++ b/conda_vendor/version.py
@@ -1,6 +1,6 @@
 import click
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 if __name__ == "__main__":
     click.echo(__version__)

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,11 +4,11 @@ channels:
 dependencies:
   - python
   - click
-  - conda-lock=1.*
+  - conda-lock>=1.2.*
   - conda-build  
   - pip
   # solvers
-  - conda=4.12.0
+  - conda
   - mamba
   - micromamba
   # teset dependencies


### PR DESCRIPTION
We had a bug in conda-vendor where the vendored repodata.json is not correct when the packages should live in the "packages.conda" subdictionary.  I've attached a quick fix.

incidentally - bumped version
needed conda-lock >= 1.2 to work on my mac.