### PR TITLE
Conda Lock Upgrades - Part 1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
       - name: "Checkout condan-vendor"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
       - name: "Checkout condan-vendor"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: "Checkout condan-vendor"

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,17 +2,15 @@ name: conda-vendor-dependencies
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python>=3.8
   - click
-  - conda-lock=1.1.2
+  - conda-lock=2.1.1
   - conda-build
   - pip
-  - pydantic=1.8.1
-  # solvers
-  - conda=4.12.0
+  - pydantic=1.10.17
+  - conda
   - mamba
   - micromamba
-  # teset dependencies
   - pytest
   - pytest-mock
   - setuptools

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+conda deactivate conda-vendor-dependencies
+conda env remove -n conda-vendor-dependencies
+
+conda env create --file environment.yaml
+conda activate conda-vendor-dependencies
+pip install -e .
+
+pytest tests/ -vvv -s

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,0 @@
-conda deactivate conda-vendor-dependencies
-conda env remove -n conda-vendor-dependencies
-
-conda env create --file environment.yaml
-conda activate conda-vendor-dependencies
-pip install -e .
-
-pytest tests/ -vvv -s

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={"console_scripts": ["conda-vendor = conda_vendor.__main__:cli"]},
     install_requires=["ruamel.yaml", "conda-lock", "click"],
     setup_requires=["wheel"],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     long_description=long_description,
     long_description_content_type="text/markdown",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ dependencies:
 # conda-locks LockSpecification object
 @pytest.fixture(scope="function")
 def lock_spec_fixture(python_conda_mirror_main_conda_forge_environment) -> LockSpecification:
-    lock_spec = get_lock_spec_for_environment_file(python_conda_mirror_main_conda_forge_environment)
+    lock_spec = get_lock_spec_for_environment_file(python_conda_mirror_main_conda_forge_environment, "linux-64")
     return lock_spec
 
 # conda-lock's DryRunInstall object

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -49,9 +49,10 @@ def test_vendor_full_runthrough(python_main_defaults_environment, tmp_path_facto
 # get _lock_spec_for_environment_file contains the packages defined in
 # the python_conda_mirror_main_conda_forge_environment test fixture
 def test_get_lock_spec_for_environmen_file(python_conda_mirror_main_conda_forge_environment):
-    lock_spec = get_lock_spec_for_environment_file(python_conda_mirror_main_conda_forge_environment)
-    assert any(versioned_dep.name == 'python' for versioned_dep in lock_spec.dependencies)
-    assert any(versioned_dep.version == '3.9.5.*' for versioned_dep in lock_spec.dependencies)
+    platform = 'linux-64'
+    lock_spec = get_lock_spec_for_environment_file(python_conda_mirror_main_conda_forge_environment, platform)
+    assert any(versioned_dep.name == 'python' for versioned_dep in lock_spec.dependencies[platform])
+    assert any(versioned_dep.version == '3.9.5.*' for versioned_dep in lock_spec.dependencies[platform])
 
 # test that solve_environment's DryRunInstall object's 
 # 'success' field is True


### PR DESCRIPTION
The purpose of this PR is to upgrade conda-lock and supporting packages to the latest supported versions, with the least disruption to the project. 

Follow-on updates will include a full upgrade of conda-lock, which will require the upgrade to pydantic v2. These changes have more affects on the code-base.

## Description

- Updated packages to latest supported versions for project
- Misc updates for conda-lock platforms argument (based on changes in this PR: https://github.com/conda/conda-lock/pull/291) 
- Fixed integration tests
- Added python 3.10 to Test Action

## Related Issue

N/A

## Motivation and Context

- Project Modernization
- Upgrade to more secure packages

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
