### PR TITLE
Conda Lock Upgrades - Part 2

### DIFF
--- a/conda_vendor/__init__.py
+++ b/conda_vendor/__init__.py
@@ -1,10 +1,10 @@
-import pkg_resources
+import importlib.metadata
 
 from conda_vendor.conda_vendor import main
 
 __all__ = ["main"]
 
 try:
-    __version__ = pkg_resources.get_distribution("conda_vendor").version
+    __version__ = importlib.metadata.version("conda_vendor")
 except Exception:
     __version__ = "unknown"

--- a/conda_vendor/conda_vendor.py
+++ b/conda_vendor/conda_vendor.py
@@ -21,7 +21,7 @@ def get_lock_spec_for_environment_file(environment_file, platform) -> LockSpecif
     if isinstance(platform, str):
         platform = [platform]
 
-    lock_spec = CondaLockWrapper.parse_environment_file(environment_file, platform)
+    lock_spec = CondaLockWrapper.parse_environment_file(Path(environment_file), platform)
     return lock_spec
 
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,10 +4,10 @@ channels:
 dependencies:
   - python>=3.8
   - click
-  - conda-lock=2.1.1
+  - conda-lock=2.5.7
   - conda-build
   - pip
-  - pydantic=1.10.17
+  - pydantic
   - conda
   - mamba
   - micromamba


### PR DESCRIPTION
Final upgrades to Conda Lock and associated packages

## Description

- Updated conda-lock to latest
- Removed pydantic version pin
- Fixed pydantic Path error
- Fixed deprecated module warning

## Related Issue

N/A

## Motivation and Context

- Project Modernization

## How Has This Been Tested?

- Local Testing

## Screenshots (if appropriate):
<img width="1346" alt="Screenshot 2024-09-19 at 2 10 06 PM" src="https://github.com/user-attachments/assets/2658cea6-aff2-4cf3-9f5c-a3e9fca8a2c2">